### PR TITLE
Add config option to automatically call preventDefault() on the onclick event

### DIFF
--- a/touchable.js
+++ b/touchable.js
@@ -330,6 +330,12 @@
 				
 			}
 			
+			if(typeof conf.preventClick!=='undefined'){
+				
+				this.preventClick=conf.preventClick;
+				
+			}
+			
 		}
 			
 		this.$elem.bind('touchstart', function(e){
@@ -344,6 +350,12 @@
 		});
 		this.$elem.bind('touchmove', touchmove);
 		this.$elem.bind('touchend', touchend);
+		
+		if (this.preventClick) {
+			this.$elem.bind('click', function (e) {
+				e.preventDefault();
+			});
+		}
 
     }
     


### PR DESCRIPTION
It would save a lot of code if when binding a `tap` event on an element, you could add a config variable to automatically call `preventDefault()` whenever this element receives an `click` event.

I would say it is a pretty common use case of this library to replace the `click` event with the `tap` event so it will work equally well on touch and non-touch devices. It is also often the case that you are binding this event to e.g. an `<a>` element, which tends to require a `preventDefault()`. Obviously it's not always the case, hence why I'm suggesting it as an option. But I think this is a good alternative to having to bind an extra event handler on every element just to call `preventDefault()`.

Usage:

``` javascript:
var a = $('body a').Touchable({preventClick: true});
a.on('tap', function (e) {
    alert('tap');
});
```

This stops us from having to repeatedly write:

``` javascript
a.on('click', function (e) {
    e.preventDefault();
});
```
