### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,10 +16,10 @@ It introduces a new event called
 * **newHover(2)**: following my [blog article][] about UI design and my postulate, that Long Tap is the new Hover. Fired when the user hovers with the mouse or longTaps an element. Hovever if you want to you can set it up to a touchmove event too, which will fire a genericHover2 event.
 [blog article]:http://grenzgenial.com/post/2429779568/longtap-is-the-new-hover
 
-##Testing##
+## Testing ##
 Right now I have tested Touchable on the following devices and browsers Chrome, Firefox, Safari, iPad Simulator, iPad, iPhone, Internet Explorer 7/8. But it should work quite everywhere. If you have any bug notes drop me a line.
 
-##Demo##
+## Demo ##
 I have setup a demo site for Hoverable on the [github page][]. View source to see how everything works.
 [github page]: http://dotmaster.github.com/Touchable-jQuery-Plugin/demo/demo.html
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
